### PR TITLE
Fix Git examples

### DIFF
--- a/examples/InstallationExample/InstallWithCocoaPods/Podfile
+++ b/examples/InstallationExample/InstallWithCocoaPods/Podfile
@@ -3,7 +3,7 @@ platform :ios
 
 target 'TestWaxPod' do
 	platform:ios, '6.0'
-	#pod 'wax', :git=>'git@github.com:alibaba/wax.git', :tag=>'1.1.0'
-    #pod 'wax', :git=>'git@github.com:alibaba/wax.git', :commit=>'5c762ad'
+	#pod 'wax', :git=>'https://github.com/alibaba/wax.git', :tag=>'1.1.0'
+    #pod 'wax', :git=>'https://github.com/alibaba/wax.git', :commit=>'5c762ad'
     pod 'wax', :path=>'../../../'
 end


### PR DESCRIPTION
Fix Git examples so they don't require authentication from a user named git and work straight away.