### PR TITLE
[NSInvocation getReturnValue:] with double/float value produces 0 unexpectedly

### DIFF
--- a/lib/wax_helpers.h
+++ b/lib/wax_helpers.h
@@ -84,6 +84,11 @@ int wax_getStackTrace(lua_State *L);
 
 // Convertion Helpers
 int wax_fromObjc(lua_State *L, const char *typeDescription, void *buffer);
+
+#ifdef __LP64__
+int wax_fromObjcForFloatOrDouble(lua_State *L, const char *typeDescription, void *buffer);
+#endif
+
 void wax_fromInstance(lua_State *L, id instance);
 void wax_fromStruct(lua_State *L, const char *typeDescription, void *buffer);
     

--- a/lib/wax_helpers.m
+++ b/lib/wax_helpers.m
@@ -103,6 +103,27 @@ int wax_getStackTrace(lua_State *L) {
     return 1;
 }
 
+#ifdef __LP64__
+int wax_fromObjcForFloatOrDouble(lua_State *L, const char *typeDescription, void *buffer) {
+    BEGIN_STACK_MODIFY(L)
+    
+    typeDescription = wax_removeProtocolEncodings(typeDescription);
+    
+    int size = wax_sizeOfTypeDescription(typeDescription);
+    
+    if (strcmp(typeDescription, "{?=f}") == 0) {
+        lua_pushnumber(L, *(float *)buffer);
+    } else if (strcmp(typeDescription, "{?=d}") == 0) {
+        lua_pushnumber(L, *(double *)buffer);
+    } else {
+        luaL_error(L, "Unable to convert Obj-C type with type description '%s', double or float expected", typeDescription);
+    }
+    
+    END_STACK_MODIFY(L, 1)
+    
+    return size;
+}
+#endif
 
 //change buffer to lua object and push stack, if it's OC object, then retain it.
 int wax_fromObjc(lua_State *L, const char *typeDescription, void *buffer) {


### PR DESCRIPTION
This bug can reproduce on iOS7 64bit devices